### PR TITLE
Bump log4j-core in /programas/practicos/2019_1_tp1/tp201901

### DIFF
--- a/programas/practicos/2019_1_tp1/tp201901/pom.xml
+++ b/programas/practicos/2019_1_tp1/tp201901/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.13.2</version>
+      <version>2.17.1</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Bumps log4j-core from 2.13.2 to 2.17.1.

---
updated-dependencies:
- dependency-name: org.apache.logging.log4j:log4j-core dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>